### PR TITLE
Currency IDs for Chracter / Currency tooltips

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -157,3 +157,10 @@ hooksecurefunc("PetBattleAura_OnEnter", function(self)
         PetBattlePrimaryAbilityTooltip.Description:SetText(oldText .. "\r\r" .. types.ability .. "|cffffffff " .. id .. "|r")
     end
 end)
+
+-- Currencies
+hooksecurefunc(GameTooltip, "SetCurrencyToken", function(self, index)
+	local link = GetCurrencyListLink(index)
+	local id = tonumber(string.match(link,"currency:(%d+)"))
+	if id then addLine(self, id, types.currency) end
+end)


### PR DESCRIPTION
This is patch 2 of a few.

This one shows the currency IDs in the window when moving the mouse over the icons on the Character / Currency frame.

There might be a better way to do this and I'm still looking around for one.  I've got hooks listening for "SetCurrencyByID" and "SetCurrencyTokenByID" to see where or how they're used.

Currencies from vendors (to buy honor gear for example) do not show the currency ID.  Looking into those frames next.