### PR TITLE
More Currency related stuff

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -157,3 +157,11 @@ hooksecurefunc("PetBattleAura_OnEnter", function(self)
         PetBattlePrimaryAbilityTooltip.Description:SetText(oldText .. "\r\r" .. types.ability .. "|cffffffff " .. id .. "|r")
     end
 end)
+
+hooksecurefunc(GameTooltip, "SetCurrencyByID", function(self, id)
+	if id then addLine(self, id, types.currency) end
+end)
+
+hooksecurefunc(GameTooltip, "SetCurrencyTokenByID", function(self, id)
+	if id then addLine(self, id, types.currency) end
+end)


### PR DESCRIPTION
"SetCurrencyByID" fires when the mouse cursor is over the rewards frame shown on garrison follower missions when the reward is a currency (Garrison Resources)

"SetCurrencyTokenByID" fires when the mouse cursor is over the garrison resources frame at the top of the garrison follower missions frame