### PR TITLE
corrected nil-Error on not initialized tradeskillwindow

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -96,7 +96,7 @@ local function attachItemTooltip(self)
   local link = select(2, self:GetItem())
   if link then
     local id = select(3, strfind(link, "^|%x+|Hitem:(%-?%d+):(%d+):(%d+):(%d+):(%d+):(%d+):(%-?%d+):(%-?%d+)"))
-    if id == "0" and TradeSkillFrame:IsVisible() then
+    if id == "0" and (TradeSkillFrame ~= nil) and TradeSkillFrame:IsVisible() then
       if (GetMouseFocus():GetName()) == "TradeSkillSkillIcon" then
         id = GetTradeSkillItemLink(TradeSkillFrame.selectedSkill):match("item:(%d+):") or nil
       else


### PR DESCRIPTION
If the tradeskillwindow is not initialized on login, the variable is nil and any time you mouseover a quest item for example the error occurs