### PR TITLE
Update idTip.lua

### DIFF
--- a/idTip.lua
+++ b/idTip.lua
@@ -121,16 +121,6 @@ ItemRefShoppingTooltip2:HookScript("OnTooltipSetItem", attachItemTooltip)
 ShoppingTooltip1:HookScript("OnTooltipSetItem", attachItemTooltip)
 ShoppingTooltip2:HookScript("OnTooltipSetItem", attachItemTooltip)
 
--- Glyphs
-hooksecurefunc(GameTooltip, "SetGlyph", function(self, ...)
-    local id = select(4, GetGlyphSocketInfo(...))
-    if id then addLine(self, id, types.glyph) end
-end)
-
-hooksecurefunc(GameTooltip, "SetGlyphByID", function(self, id)
-    if id then addLine(self, id, types.glyph) end
-end)
-
 -- Achievement Frame Tooltips
 local f = CreateFrame("frame")
 f:RegisterEvent("ADDON_LOADED")


### PR DESCRIPTION
Remove hooks to glyphs' tooltip frame since it no longer exists.  This prevents the errors shown when the script loads.

Solves issue #16 