### PR TITLE
Show species id and npc id on Pet Journal info tooltip.

### DIFF
--- a/idTip.lua
+++ b/idTip.lua
@@ -23,6 +23,7 @@ local kinds = {
   equipmentset = "EquipmentSetID",
   visual = "VisualID",
   source = "SourceID",
+  species = "SpeciesID",
 }
 
 local isClassicWow = select(4,GetBuildInfo()) < 20000
@@ -162,6 +163,16 @@ if not isClassicWow then
     local spellID = select(6, GetPvpTalentInfoByID(id))
     addLine(self, id, kinds.talent)
     addLine(self, spellID, kinds.spell)
+  end)
+
+  -- Pet Journal team icon
+  hooksecurefunc(GameTooltip, "SetCompanionPet", function(self, petID)
+    local speciesID = select(1, C_PetJournal.GetPetInfoByPetID(petID));
+    if speciesID then
+      local npcId = select(4, C_PetJournal.GetPetInfoBySpeciesID(speciesID));
+      addLine(GameTooltip, speciesID, kinds.species);
+      addLine(GameTooltip, npcId, kinds.unit);
+    end
   end)
 end
 -- NPCs
@@ -310,6 +321,15 @@ f:SetScript("OnEvent", function(_, _, what)
       if #sourceIDs ~= 0 then addLine(GameTooltip, sourceIDs, kinds.source) end
       if #itemIDs ~= 0 then addLine(GameTooltip, itemIDs, kinds.item) end
     end)
+
+    -- Pet Journal selected pet info icon
+    PetJournalPetCardPetInfo:HookScript("OnEnter", function(self)
+      if PetJournalPetCard.speciesID then
+        local npcId = select(4, C_PetJournal.GetPetInfoBySpeciesID(PetJournalPetCard.speciesID));
+        addLine(GameTooltip, PetJournalPetCard.speciesID, kinds.species);
+        addLine(GameTooltip, npcId, kinds.unit);
+      end
+    end);
   end
 end)
 


### PR DESCRIPTION
Show species id and npc id on the pet journal tooltip. Useful for pets that are not collected yet as you cannot shift-click to link them.

<img width="215" alt="Wow_2019-11-09_15-08-04" src="https://user-images.githubusercontent.com/54618193/68538059-4f749300-0323-11ea-830c-c7f8e896a348.png">
<img width="233" alt="Wow_2019-11-09_15-10-34" src="https://user-images.githubusercontent.com/54618193/68538061-54394700-0323-11ea-99d9-18d75fa2ed88.png">
<img width="179" alt="Wow_2019-11-09_18-23-25" src="https://user-images.githubusercontent.com/54618193/68538062-57343780-0323-11ea-9c9f-85df1419ed59.png">

