### PR TITLE
Implement mission id

### DIFF
--- a/idTip.lua
+++ b/idTip.lua
@@ -25,6 +25,7 @@ local kinds = {
   source = "SourceID",
   species = "SpeciesID",
   icon = "IconID",
+  mission = "MissionID",
 }
 
 local isClassicWow = select(4,GetBuildInfo()) < 90000
@@ -346,6 +347,14 @@ f:SetScript("OnEvent", function(_, _, what)
     hooksecurefunc("AddAutoCombatSpellToTooltip", function (self, info)
       if info and info.autoCombatSpellID then
         addLine(self, info.autoCombatSpellID, kinds.ability)
+      end
+    end)
+
+    -- mission id (it's work without VenturePlan)
+    hooksecurefunc("CovenantMissionInfoTooltip_OnEnter", function(self)
+      if self.info then
+        addLine(GameTooltip, self.info.missionID, kinds.mission)
+        GameTooltip:Show()
       end
     end)
   end


### PR DESCRIPTION

Add mission id to GameTooltip.
Note: It's work without VenturePlan.

![image](https://user-images.githubusercontent.com/82728/132926688-a03b6d0f-7717-4c3a-a5bc-b758bd8ebc66.png)


Signed-off-by: Konctantin <gawrilyako@gmail.com>