### PR TITLE
Added missing end on addFromData method

### DIFF
--- a/idTip.lua
+++ b/idTip.lua
@@ -116,6 +116,7 @@ local function addFromData(tooltip, data, kind)
   else if data.id then
     addLine(tooltip, data.id, kind)
   end
+  end
 end
 
 -- https://github.com/Ketho/wow-ui-source-df/blob/e6d3542fc217592e6144f5934bf22c5d599c1f6c/Interface/AddOns/Blizzard_APIDocumentationGenerated/TooltipInfoSharedDocumentation.lua


### PR DESCRIPTION
Getting the following error ingame: "idTip/idTip.lua:454: 'end' expected (to close 'function' at line 112) near '<eof>'". This change fixed it locally.