### PR TITLE
Update for Midnight

### DIFF
--- a/idTip.lua
+++ b/idTip.lua
@@ -1,12 +1,12 @@
 local addonName = ...
 
-local GetSpellTexture = (C_Spell and C_Spell.GetSpellTexture) and C_Spell.GetSpellTexture or GetSpellTexture
-local GetItemIconByID = (C_Item and C_Item.GetItemIconByID) and C_Item.GetItemIconByID or GetItemIconByID
-local GetItemInfo = (C_Item and C_Item.GetItemInfo) and C_Item.GetItemInfo or GetItemInfo
-local GetItemGem = (C_Item and C_Item.GetItemGem) and C_Item.GetItemGem or GetItemGem
-local GetItemSpell = (C_Item and C_Item.GetItemSpell) and C_Item.GetItemSpell or GetItemSpell
+local GetSpellTexture = (C_Spell and C_Spell.GetSpellTexture and not issecretvalue(C_Spell.GetSpellTexture)) and C_Spell.GetSpellTexture or GetSpellTexture
+local GetItemIconByID = (C_Item and C_Item.GetItemIconByID and not issecretvalue(C_Item.GetItemIconByID)) and C_Item.GetItemIconByID or GetItemIconByID
+local GetItemInfo = (C_Item and C_Item.GetItemInfo and not issecretvalue(C_Item.GetItemInfo)) and C_Item.GetItemInfo or GetItemInfo
+local GetItemGem = (C_Item and C_Item.GetItemGem and not issecretvalue(C_Item.GetItemGem)) and C_Item.GetItemGem or GetItemGem
+local GetItemSpell = (C_Item and C_Item.GetItemSpell and not issecretvalue(C_Item.GetItemSpell)) and C_Item.GetItemSpell or GetItemSpell
 local GetRecipeReagentItemLink = (C_TradeSkillUI and C_TradeSkillUI.GetRecipeReagentItemLink) and C_TradeSkillUI.GetRecipeReagentItemLink or GetTradeSkillReagentItemLink
-local GetItemLinkByGUID = (C_Item and C_Item.GetItemLinkByGUID) and C_Item.GetItemLinkByGUID
+local GetItemLinkByGUID = (C_Item and C_Item.GetItemLinkByGUID and not issecretvalue(C_Item.GetItemLinkByGUID)) and C_Item.GetItemLinkByGUID
 
 local kinds = {
   spell = "SpellID",
@@ -115,7 +115,7 @@ local function addLine(tooltip, id, kind)
   for i = tooltip:NumLines(), 1, -1 do
     frame = _G[name .. "TextLeft" .. i]
     if frame then text = frame:GetText() end
-    if text and string.find(text, kinds[kind]) then return end
+    if not issecretvalue(text) and text and string.find(text, kinds[kind]) then return end
   end
 
   local multiple = type(id) == "table"
@@ -262,7 +262,7 @@ end
 
 if TooltipDataProcessor then
   TooltipDataProcessor.AddTooltipPostCall(TooltipDataProcessor.AllTypes, function(tooltip, data)
-    if not data or not data.type then return end
+    if issecretvalue(data) or issecretvalue(data.type) or not data or not data.type then return end
     local kind = kindsByID[tonumber(data.type)]
 
     -- unit special handling

--- a/idTip.toc
+++ b/idTip.toc
@@ -1,6 +1,6 @@
-## Interface: 11507, 50500, 50501, 110200, 110205
+## Interface: 12000, 11507, 50500, 50501, 110200, 110205
 ## Title: idTip
-## Version: 11.5.25
+## Version: 11.5.26
 ## Notes: Adds various IDs to tooltips
 ## Author: silverwind
 ## X-Curse-Project-ID: 24541


### PR DESCRIPTION
This adds issecretvalue() checks to make sure spell and items are not secretly returned. If they are secret, do not generate the tooltip. C_TradeSkillUI.GetRecipeReagentItemLink appears to have been discontinued so I didn't do anything to that at this time. There maybe a usage of the secretunwrap() and/or canaccessvalue() functions but I have not figured it out yet. But for the time being this just allows the mod to not throw any errors while in combat.

https://www.townlong-yak.com/framexml/beta/Blizzard_APIDocumentation#secretunwrap